### PR TITLE
fix(analytics): string parameters in `logEvent` are sent as `String` instead of the parameter value

### DIFF
--- a/.changeset/hip-masks-mix.md
+++ b/.changeset/hip-masks-mix.md
@@ -1,0 +1,5 @@
+---
+"@capacitor-firebase/analytics": patch
+---
+
+fix(android): string parameters in `logEvent` are sent as `String` instead of the parameter value

--- a/packages/analytics/android/src/main/java/dev/robingenz/capacitorjs/plugins/firebase/analytics/FirebaseAnalyticsHelper.java
+++ b/packages/analytics/android/src/main/java/dev/robingenz/capacitorjs/plugins/firebase/analytics/FirebaseAnalyticsHelper.java
@@ -109,7 +109,7 @@ public class FirebaseAnalyticsHelper {
                         }
                         break;
                     default:
-                        bundle.putString(key, value.getClass().getSimpleName());
+                        bundle.putString(key, (String) value);
                 }
             }
         } catch (JSONException exception) {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).

Close #75 
