### PR TITLE
fix(messaging): APNS device token not set before retrieving FCM Token on iOS

### DIFF
--- a/.changeset/weak-radios-clap.md
+++ b/.changeset/weak-radios-clap.md
@@ -1,0 +1,5 @@
+---
+"@capacitor-firebase/messaging": patch
+---
+
+fix(ios): APNS device token not set before retrieving FCM Token

--- a/packages/messaging/ios/Plugin/FirebaseMessaging.swift
+++ b/packages/messaging/ios/Plugin/FirebaseMessaging.swift
@@ -16,11 +16,9 @@ import FirebaseCore
         if FirebaseApp.app() == nil {
             FirebaseApp.configure()
         }
+        UIApplication.shared.registerForRemoteNotifications()
         Messaging.messaging().delegate = self
         self.plugin.bridge?.notificationRouter.pushNotificationHandler = self
-        DispatchQueue.main.async {
-            UIApplication.shared.registerForRemoteNotifications()
-        }
     }
 
     public func requestPermissions(completion: @escaping (_ granted: Bool, _ error: Error?) -> Void) {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
- [x] A changeset has been created (`npm run changeset`).

Close #115 